### PR TITLE
rename project to yadro-snmp

### DIFF
--- a/agent/Makefile.am
+++ b/agent/Makefile.am
@@ -1,8 +1,8 @@
 AM_CPPFLAGS = -iquote $(top_srcdir)
 
-sbin_PROGRAMS = phosphor-snmp-agent
+sbin_PROGRAMS = yadro-snmp-agent
 
-phosphor_snmp_agent_SOURCES = 	\
+yadro_snmp_agent_SOURCES = 		\
 		snmp.cpp 				\
 		yadro/powerstate.cpp 	\
 		yadro/sensors.cpp 		\
@@ -10,6 +10,6 @@ phosphor_snmp_agent_SOURCES = 	\
 		yadro/inventory.cpp 	\
 		main.cpp
 
-phosphor_snmp_agent_CXXFLAGS = $(SDBUSPLUS_CFLAGS) $(NETSNMP_CFLAGS)
-phosphor_snmp_agent_LDADD = $(SDBUSPLUS_LIBS) $(NETSNMP_AGENT_LIBS)
+yadro_snmp_agent_CXXFLAGS = $(SDBUSPLUS_CFLAGS) $(NETSNMP_CFLAGS)
+yadro_snmp_agent_LDADD = $(SDBUSPLUS_LIBS) $(NETSNMP_AGENT_LIBS)
 

--- a/agent/data/enums.hpp
+++ b/agent/data/enums.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief DBus enums to base type converter.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/data/scalar.hpp
+++ b/agent/data/scalar.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief Export DBus property to scalar MIB value
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/data/table.hpp
+++ b/agent/data/table.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief Export DBus objects tree to MIB table
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/data/table/item.hpp
+++ b/agent/data/table/item.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief MIB tables item definition.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/main.cpp
+++ b/agent/main.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief SNMP Agent entry point
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/snmp.cpp
+++ b/agent/snmp.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief SNMP Agent implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/snmp.hpp
+++ b/agent/snmp.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief SNMP Agent implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/snmp_oid.hpp
+++ b/agent/snmp_oid.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief SNMP OID manipulation helper.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/snmptrap.hpp
+++ b/agent/snmptrap.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief SNMP Traps implementation
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/snmpvars.hpp
+++ b/agent/snmpvars.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief netsnmp_variable_list C++ wrapper.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/tracing.hpp
+++ b/agent/tracing.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief TRACE_* macroses definitions.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/inventory.cpp
+++ b/agent/yadro/inventory.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO inventory table implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/inventory.hpp
+++ b/agent/yadro/inventory.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO inventory table implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/powerstate.cpp
+++ b/agent/yadro/powerstate.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO host power state implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/powerstate.hpp
+++ b/agent/yadro/powerstate.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO host power state implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/sensors.cpp
+++ b/agent/yadro/sensors.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO sensors tables implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/sensors.hpp
+++ b/agent/yadro/sensors.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO sensors tables implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/software.cpp
+++ b/agent/yadro/software.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO software table implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/software.hpp
+++ b/agent/yadro/software.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADRO software tables implementation.
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/agent/yadro/yadro_oid.hpp
+++ b/agent/yadro/yadro_oid.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief YADOR OID helper
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([phosphor-snmp], 
+AC_INIT([yadro-snmp], 
         [m4_esyscmd_s([git describe --dirty --long --always])], 
         [https://github.com/YADRO-KNS/phosphor-snmp/issues])
 AC_LANG([C++])
@@ -45,9 +45,9 @@ AC_SUBST([NETSNMP_AGENT_LIBS])
 LT_INIT # Required for systemd linking
 
 AC_ARG_ENABLE([agent],
-    AS_HELP_STRING([--disable-agent], [Disable phosphor-snmp-agent.]))
+    AS_HELP_STRING([--disable-agent], [Disable yadro-snmp-agent.]))
 AC_ARG_ENABLE([cfg-manager],
-    AS_HELP_STRING([--disable-cfg-manager], [Disable phosphor-snmp-cfg-manager.]))
+    AS_HELP_STRING([--disable-cfg-manager], [Disable yadro-snmp-cfg-manager.]))
 
 AM_CONDITIONAL([WANT_AGENT], [test "x$enable_agent" != "xno"])
 AM_CONDITIONAL([WANT_CFG_MANAGER], [test "x$enable_cfg_manager" != "xno"])

--- a/sdevent/event.hpp
+++ b/sdevent/event.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief sd_event C++ wrapper
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/sdevent/source.hpp
+++ b/sdevent/source.hpp
@@ -1,7 +1,7 @@
 /**
  * @brief sd_event_source C++ wrapper
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *

--- a/snmpcfg/Makefile.am
+++ b/snmpcfg/Makefile.am
@@ -1,14 +1,14 @@
-sbin_PROGRAMS = phosphor-snmpcfg 
+sbin_PROGRAMS = yadro-snmpcfg 
 
 nobase_nodist_include_HEADERS = \
 	xyz/openbmc_project/SNMPCfg/server.hpp
 
-phosphor_snmpcfg_SOURCES = \
+yadro_snmpcfg_SOURCES = \
 	snmpcfg-server.cpp \
 	xyz/openbmc_project/SNMPCfg/server.cpp 
 
-phosphor_snmpcfg_CXXFLAGS = $(SDBUSPLUS_CFLAGS)
-phosphor_snmpcfg_LDADD = $(SDBUSPLUS_LIBS)
+yadro_snmpcfg_CXXFLAGS = $(SDBUSPLUS_CFLAGS)
+yadro_snmpcfg_LDADD = $(SDBUSPLUS_LIBS)
 
 # Be sure to build needed files before compiling
 BUILT_SOURCES = \

--- a/snmpcfg/snmpcfg-server.cpp
+++ b/snmpcfg/snmpcfg-server.cpp
@@ -1,7 +1,7 @@
 /**
  * @brief SNMP Configuration manager
  *
- * This file is part of phosphor-snmp project.
+ * This file is part of yadro-snmp project.
  *
  * Copyright (c) 2018 YADRO
  *


### PR DESCRIPTION
OpenBMC team now have project `phosphor-snmp`.
To prevent conflict in project names we decided to rename this project.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>