### PR TITLE
Use C++17 and std::variant

### DIFF
--- a/agent/data/scalar.hpp
+++ b/agent/data/scalar.hpp
@@ -137,7 +137,7 @@ template <typename T> class Scalar
      */
     virtual void setValue(value_t& var)
     {
-        auto newValue = var.template get<T>();
+        auto newValue = sdbusplus::message::variant_ns::get<T>(var);
         std::swap(_value, newValue);
     }
 

--- a/agent/data/table/item.hpp
+++ b/agent/data/table/item.hpp
@@ -36,7 +36,18 @@ namespace table
  */
 template <typename... T> struct Item
 {
-    using variant_t = sdbusplus::message::variant<T...>;
+    /*
+     * The `std::variant` allows to keep duplicates of types,
+     * but `std::get<>()` and `std::holds_alternative<>()` is ill-formed
+     * in this case.
+     *
+     * So we can't use here:
+     *   using variant_t = sdbusplus::message::variant<T...>;
+     * and we should specify all possible types.
+     */
+    using variant_t =
+        sdbusplus::message::variant<int64_t, std::string, bool, uint8_t>;
+
     using values_t = std::tuple<T...>;
     using fields_map_t = std::map<std::string, variant_t>;
 
@@ -112,10 +123,10 @@ template <typename... T> struct Item
     {
         using FieldType = typename std::tuple_element<Index, values_t>::type;
         if (fieldsMap.find(propertyName) != fieldsMap.end() &&
-            fieldsMap.at(propertyName).template is<FieldType>())
+            std::holds_alternative<FieldType>(fieldsMap.at(propertyName)))
         {
             std::get<Index>(data) =
-                fieldsMap.at(propertyName).template get<FieldType>();
+                std::get<FieldType>(fieldsMap.at(propertyName));
         }
     }
 

--- a/agent/yadro/sensors.cpp
+++ b/agent/yadro/sensors.cpp
@@ -171,10 +171,10 @@ struct Sensor
 
         constexpr auto Scale = "Scale";
         if (fields.find(Scale) != fields.end() &&
-            fields.at(Scale).is<int64_t>())
+            std::holds_alternative<int64_t>(fields.at(Scale)))
         {
             std::get<FIELD_SENSOR_SCALE>(data) = static_cast<int64_t>(
-                powf(10.f, _power - fields.at(Scale).get<int64_t>()));
+                powf(10.f, _power - std::get<int64_t>(fields.at(Scale))));
         }
 
         auto lastState = getState();

--- a/agent/yadro/software.cpp
+++ b/agent/yadro/software.cpp
@@ -100,10 +100,10 @@ struct Software : public phosphor::snmp::data::table::Item<std::string, uint8_t,
                       const phosphor::snmp::data::DBusEnum<uint8_t>& enumcvt)
     {
         if (fields.find(field) != fields.end() &&
-            fields.at(field).is<std::string>())
+            std::holds_alternative<std::string>(fields.at(field)))
         {
             std::get<Idx>(data) =
-                enumcvt.get(fields.at(field).get<std::string>());
+                enumcvt.get(std::get<std::string>(fields.at(field)));
         }
     }
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
 
 # Checks for typedefs, structures and compiler characteristics.
-AX_CXX_COMPILE_STDCXX_14([noext])
+AX_CXX_COMPILE_STDCXX_17([noext])
 AX_APPEND_COMPILE_FLAGS([-fpic -Wall -Werror], [CXXFLAGS])
 
 # Checks for libraries.


### PR DESCRIPTION
All projects in the OpenBMC now used C++17 and the `sdbusplus` now used
`std::variant` instead `mapbox::vairant`.

These changes are required to fix the build in these new conditions and
don't have any modification of the logic.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>