### PR TITLE
Improve zabbix integration

### DIFF
--- a/agent/yadro/inventory.cpp
+++ b/agent/yadro/inventory.cpp
@@ -131,6 +131,10 @@ struct InventoryItem : public phosphor::snmp::data::table::Item<
 
         switch (tinfo->colnum)
         {
+            case COLUMN_YADROINVENTORY_PATH:
+                VariableList::set(request->requestvb, name);
+                break;
+
             case COLUMN_YADROINVENTORY_NAME:
                 VariableList::set(request->requestvb,
                                   std::get<FIELD_INVENTORY_PRETTY_NAME>(data));
@@ -228,7 +232,7 @@ void init()
     inventoryTable.update();
     inventoryTable.init_mib("yadroInventoryTable", inventoryTableOid.data(),
                             inventoryTableOid.size(),
-                            InventoryItem::COLUMN_YADROINVENTORY_NAME,
+                            InventoryItem::COLUMN_YADROINVENTORY_PATH,
                             InventoryItem::COLUMN_YADROINVENTORY_FUNCTIONAL);
 }
 

--- a/agent/yadro/sensors.cpp
+++ b/agent/yadro/sensors.cpp
@@ -257,6 +257,10 @@ struct Sensor
 
         switch (tinfo->colnum)
         {
+            case COLUMN_YADROSENSOR_NAME:
+                VariableList::set(request->requestvb, name);
+                break;
+
             case COLUMN_YADROSENSOR_VALUE:
                 VariableList::set(request->requestvb,
                                   getValue<FIELD_SENSOR_VALUE>());
@@ -358,7 +362,7 @@ void init()
     for (auto& s : sensors)
     {
         s.init_mib(s.tableName.c_str(), s.tableOID.data(), s.tableOID.size(),
-                   Sensor::COLUMN_YADROSENSOR_VALUE,
+                   Sensor::COLUMN_YADROSENSOR_NAME,
                    Sensor::COLUMN_YADROSENSOR_STATE);
         s.update();
     }

--- a/agent/yadro/software.cpp
+++ b/agent/yadro/software.cpp
@@ -156,6 +156,10 @@ struct Software : public phosphor::snmp::data::table::Item<std::string, uint8_t,
 
         switch (tinfo->colnum)
         {
+            case COLUMN_YADROSOFTWARE_HASH:
+                VariableList::set(request->requestvb, name);
+                break;
+
             case COLUMN_YADROSOFTWARE_VERSION:
                 VariableList::set(request->requestvb,
                                   std::get<FIELD_SOFTWARE_VERSION>(data));
@@ -204,7 +208,7 @@ void init()
     softwareTable.update();
     softwareTable.init_mib("yadroSoftwareTable", softwareOid,
                            OID_LENGTH(softwareOid),
-                           Software::COLUMN_YADROSOFTWARE_VERSION,
+                           Software::COLUMN_YADROSOFTWARE_HASH,
                            Software::COLUMN_YADROSOFTWARE_PRIORITY);
 }
 


### PR DESCRIPTION
`zabbix` wants to get the table index as a read-only field.
This commit brings modified revision of `YADRO-MIB.txt` and
corresponding changes in the table implementations.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>