### PR TITLE
snmp-agent: restart agent synchronously with snmpd

### DIFF
--- a/agent/yadro-snmp-agent.service.in
+++ b/agent/yadro-snmp-agent.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Yadro SNMP Sub Agent
-Wants=snmpd.service
+PartOf=snmpd.service
 After=snmpd.service
 After=obmc-mapper.target
 
@@ -12,4 +12,4 @@ ExecStart=@bindir@/yadro-snmp-agent $OPTIONS
 SyslogIdentifier=yadro-snmp
 
 [Install]
-WantedBy=@SYSTEMD_TARGET@
+WantedBy=snmpd.service


### PR DESCRIPTION
This makes snmp-agent starting, stopping and restarting synchronously
with snmpd.service.
This improves the management via `service-config-manager`.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>